### PR TITLE
upgrade calcit tools; display more info about local variable

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -343,6 +343,169 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612336820681) (:text |file)
                   |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612338642511) (:text |states)
+          |comp-preview $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448127952)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448129893) (:text |defcomp)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448127952) (:text |comp-preview)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448127952)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448133556) (:text |data)
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448511858)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448133989)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448134447) (:text |div)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448134646)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448136212) (:text |{})
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448155212)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448155941) (:text |:style)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448158669)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448158983) (:text |{})
+                                  |yr $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448428018)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448430245) (:text |:font-size)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448432784) (:text |12)
+                                  |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448392064)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448402511) (:text |:white-space)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448397778) (:text |:pre)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448159996)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448162215) (:text |:position)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448163483) (:text |:absolute)
+                                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448171422)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448177021) (:text |:background-color)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448488469)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448489096) (:text |hsl)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448489638) (:text |0)
+                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448489950) (:text |0)
+                                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448491899) (:text |100)
+                                          |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448503941) (:text |0.6)
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448166117)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448168423) (:text |:right)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448168595) (:text |0)
+                                  |yj $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448405949)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448408568) (:text |:border)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448408835)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448409532) (:text |str)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448412906) (:text "|\"1px solid ")
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448413772)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448414193) (:text |hsl)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448414522) (:text |0)
+                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448414805) (:text |0)
+                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448415914) (:text |90)
+                                  |yx $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448461738)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448462930) (:text |:padding)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448464644) (:text |8)
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448163881)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448164816) (:text |:bottom)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448165602) (:text |0)
+                                  |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448383087)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448384923) (:text |:font-family)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448390322) (:text |ui/font-code)
+                                  |yv $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448433764)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448436765) (:text |:line-height)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448442353) (:text "|\"20px")
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448136873)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448206043) (:text |div)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448138493)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448138747) (:text |{})
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448144696)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448147131) (:text |:innerText)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448420911)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448148226)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448150272) (:text |write-cirru-edn)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448151534) (:text |data)
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448421668) (:text |trim)
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448603576)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448604520) (:text |div)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448604785)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448605116) (:text |{})
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448632545)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448634781) (:text |:inner-text)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448635948) (:text "|\"×")
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448644333)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448645741) (:text |:style)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448646039)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448647368) (:text |{})
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448647807)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448649794) (:text |:position)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448651878) (:text |:absolute)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448652514)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448653919) (:text |:top)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448654536) (:text |4)
+                                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448655118)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448657601) (:text |:right)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448657900) (:text |4)
+                                      |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448658799)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448661699) (:text |:color)
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448662800)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448663230) (:text |hsl)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448663672) (:text |0)
+                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448664228) (:text |80)
+                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448665092) (:text |60)
+                                      |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448670603)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448671857) (:text |:cursor)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448672932) (:text |:pointer)
+                                      |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448709803)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448711695) (:text |:font-size)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448712085) (:text |14)
+                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448674166)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448677592) (:text |:on-click)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448677961)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448678278) (:text |fn)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448678531)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448678707) (:text |e)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448679713) (:text |d!)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448680167)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448680576) (:text |d!)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448681844) (:text |:preview)
+                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448682882) (:text |nil)
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448512388) (:text |if)
+                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448512689)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448514943) (:text |some?)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448515450) (:text |data)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448531780)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448532495) (:text |div)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448532853)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448534988) (:text |{})
           |comp-fn $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612339104485)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612339106540) (:text |defcomp)
@@ -1232,6 +1395,13 @@
                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612336600076) (:text "|\"No file slected: ")
                                               |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612336599312) (:text |str)
                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612336603738) (:text |selected)
+                      |wT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448120603)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448123650) (:text |comp-preview)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448123895)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448124968) (:text |:preview)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448126588) (:text |store)
           |comp-header $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612334422846)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612334425148) (:text |defcomp)
@@ -1361,7 +1531,8 @@
                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612334422846) (:text |.readAsText)
                                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612334422846) (:text |fr)
                                           |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612334422846) (:text |file)
-              |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612334427897) (:data $ {})
+              |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612334427897)
+                :data $ {}
           |comp-symbol $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342159839)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342163547) (:text |defcomp)
@@ -1412,13 +1583,31 @@
                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342161340)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342161340) (:text |:style)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342161340)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615446961770)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342161340) (:text |{})
-                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342161340)
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342161340)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342161340) (:text |:display)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342161340) (:text |:inline-block)
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342161340) (:text |{})
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342161340)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342161340) (:text |:display)
+                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342161340) (:text |:inline-block)
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615446964008) (:text |merge)
+                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447574315)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447576930) (:text |:on-click)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447577229)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447577517) (:text |fn)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447577745)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447577901) (:text |e)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447578472) (:text |d!)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447579857)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448316893) (:text |d!)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447583380) (:text |expr)
+                                          |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448320112) (:text |:preview)
                           |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342335507)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342335507) (:text |<>)
@@ -1427,6 +1616,52 @@
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342335507) (:text |get)
                                   |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342335507) (:text |expr)
                                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612342335507) (:text "|\"val")
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |case-default)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447611925)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447611925) (:text |->)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447611925) (:text |expr)
+                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447611925)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447611925) (:text |get)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447611925) (:text "|\"resolved")
+                                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447611925)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447611925) (:text |get)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447611925) (:text "|\"kind")
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |nil)
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text "|\"resolvedLocal")
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |{})
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |:color)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |hsl)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447534906) (:text |200)
+                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447527215) (:text |80)
+                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447510147) (:text |70)
+                                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text "|\"notResolved")
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |{})
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |:color)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615447339192)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447339192) (:text |hsl)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447518871) (:text |150)
+                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447528922) (:text |80)
+                                                  |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615447552905) (:text |70)
                       |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342946252)
                         :data $ {}
                           |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612342337694)
@@ -1576,7 +1811,8 @@
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612339931493) (:text |get)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612339931851) (:text |x)
                           |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612339933784) (:text "|\"kind")
-        :proc $ {} (:type :expr) (:at 1499755354983) (:data $ {})
+        :proc $ {} (:type :expr) (:at 1499755354983)
+          :data $ {}
       |app.config $ {}
         :ns $ {} (:type :expr) (:by |root) (:at 1527788237503)
           :data $ {}
@@ -1648,7 +1884,8 @@
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1544956719115) (:text |:storage-key)
                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1544956719115) (:text "|\"workflow")
-        :proc $ {} (:type :expr) (:by |root) (:at 1527788237503) (:data $ {})
+        :proc $ {} (:type :expr) (:by |root) (:at 1527788237503)
+          :data $ {}
       |app.main $ {}
         :ns $ {} (:type :expr) (:at 1499755354983)
           :data $ {}
@@ -1749,7 +1986,8 @@
                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1610793079106)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1610793079545) (:text |fn)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1610793080160) (:data $ {})
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1610793080160)
+                        :data $ {}
                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1610793080941)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1610793083422) (:text |repeat!)
@@ -1820,6 +2058,9 @@
                       |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1612336304761)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612336306453) (:text |event)
+              |s $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615446752731)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615446757673) (:text |load-console-formatter!)
               |yT $ {} (:type :expr) (:at 1499755354983)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |root) (:at 1499755354983) (:text |println)
@@ -1857,7 +2098,8 @@
                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1544874446442) (:text |config/dev?)
                       |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1544874449063) (:text "|\"dev")
                       |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1544874452316) (:text "|\"release")
-              |r $ {} (:type :expr) (:at 1499755354983) (:data $ {})
+              |r $ {} (:type :expr) (:at 1499755354983)
+                :data $ {}
               |y $ {} (:type :expr) (:at 1499755354983)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |root) (:at 1499755354983) (:text |add-watch)
@@ -1912,7 +2154,8 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1533919517365) (:text |defn)
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1533919515671) (:text |persist-storage!)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1533919515671) (:data $ {})
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1533919515671)
+                :data $ {}
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1533919515671)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1533919515671) (:text |.setItem)
@@ -1953,7 +2196,8 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1551977434239) (:text |defn)
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1551977434239) (:text |snippets)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1551977434239) (:data $ {})
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1551977434239)
+                :data $ {}
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1551977444630)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1551977458023) (:text |println)
@@ -1983,7 +2227,8 @@
             :data $ {}
               |T $ {} (:type :leaf) (:by |root) (:at 1499755354983) (:text |defn)
               |j $ {} (:type :leaf) (:by |root) (:at 1499755354983) (:text |reload!)
-              |r $ {} (:type :expr) (:at 1499755354983) (:data $ {})
+              |r $ {} (:type :expr) (:at 1499755354983)
+                :data $ {}
               |u $ {} (:type :expr) (:by |root) (:at 1507461699387)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |root) (:at 1507461702453) (:text |clear-cache!)
@@ -2027,7 +2272,8 @@
                   |T $ {} (:type :leaf) (:by |root) (:at 1499755354983) (:text |.querySelector)
                   |j $ {} (:type :leaf) (:by |root) (:at 1499755354983) (:text |js/document)
                   |r $ {} (:type :leaf) (:by |root) (:at 1499755354983) (:text ||.app)
-        :proc $ {} (:type :expr) (:at 1499755354983) (:data $ {})
+        :proc $ {} (:type :expr) (:at 1499755354983)
+          :data $ {}
       |app.schema $ {}
         :ns $ {} (:type :expr) (:at 1499755354983)
           :data $ {}
@@ -2057,7 +2303,12 @@
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612278910760) (:text |:ir-data)
                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612278911691) (:text |nil)
-        :proc $ {} (:type :expr) (:at 1499755354983) (:data $ {})
+                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448083836)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448087864) (:text |:preview)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448089423) (:text |nil)
+        :proc $ {} (:type :expr) (:at 1499755354983)
+          :data $ {}
       |app.updater $ {}
         :ns $ {} (:type :expr) (:at 1499755354983)
           :data $ {}
@@ -2116,5 +2367,23 @@
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612278897222) (:text |store)
                           |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612278899268) (:text |:ir)
                           |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1612279284132) (:text |data)
-        :proc $ {} (:type :expr) (:at 1499755354983) (:data $ {})
-  :configs $ {} (:reload-fn |app.main/reload!) (:modules $ [] |respo.calcit/compact.cirru |lilac/compact.cirru |memof/compact.cirru |respo-ui.calcit/compact.cirru |respo-markdown.calcit/compact.cirru |reel.calcit/compact.cirru) (:output |src) (:port 6001) (:extension |.cljs) (:init-fn |app.main/main!) (:compact-output? true) (:storage-key |calcit.cirru) (:version |0.0.1)
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448303647)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448306456) (:text |:preview)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1615448307167)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448308056) (:text |assoc)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448309356) (:text |store)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448311610) (:text |:preview)
+                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1615448312196) (:text |data)
+        :proc $ {} (:type :expr) (:at 1499755354983)
+          :data $ {}
+  :configs $ {} (:reload-fn |app.main/reload!)
+    :modules $ [] |respo.calcit/compact.cirru |lilac/compact.cirru |memof/compact.cirru |respo-ui.calcit/compact.cirru |respo-markdown.calcit/compact.cirru |reel.calcit/compact.cirru
+    :output |src
+    :port 6001
+    :extension |.cljs
+    :init-fn |app.main/main!
+    :compact-output? true
+    :storage-key |calcit.cirru
+    :version |0.0.1

--- a/compact.cirru
+++ b/compact.cirru
@@ -1,16 +1,26 @@
 
 {} (:package |app)
-  :configs $ {} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!) (:modules $ [] |respo.calcit/compact.cirru |lilac/compact.cirru |memof/compact.cirru |respo-ui.calcit/compact.cirru |respo-markdown.calcit/compact.cirru |reel.calcit/compact.cirru) (:version |0.0.1)
+  :configs $ {} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!)
+    :modules $ [] |respo.calcit/compact.cirru |lilac/compact.cirru |memof/compact.cirru |respo-ui.calcit/compact.cirru |respo-markdown.calcit/compact.cirru |reel.calcit/compact.cirru
+    :version |0.0.1
   :files $ {}
     |app.comp.container $ {}
       :ns $ quote
-        ns app.comp.container $ :require ([] respo-ui.core :as ui) ([] respo.core :refer $ [] defcomp defeffect <> >> div button textarea span input) ([] respo.comp.space :refer $ [] =<) ([] reel.comp.reel :refer $ [] comp-reel) ([] respo-md.comp.md :refer $ [] comp-md) ([] app.config :refer $ [] dev?) ([] memof.alias :refer $ [] memof-call) ([] respo.util.format :refer $ [] hsl)
+        ns app.comp.container $ :require ([] respo-ui.core :as ui)
+          [] respo.core :refer $ [] defcomp defeffect <> >> div button textarea span input
+          [] respo.comp.space :refer $ [] =<
+          [] reel.comp.reel :refer $ [] comp-reel
+          [] respo-md.comp.md :refer $ [] comp-md
+          [] app.config :refer $ [] dev?
+          [] memof.alias :refer $ [] memof-call
+          [] respo.util.format :refer $ [] hsl
       :defs $ {}
         |comp-file $ quote
           defcomp comp-file (states file)
             let
                 cursor $ :cursor states
-                state $ either (:data states) ({} $ :selected nil)
+                state $ either (:data states)
+                  {} $ :selected nil
                 selected $ :selected state
               div
                 {} $ :style (merge ui/expand ui/column)
@@ -21,34 +31,61 @@
                     div
                       {} $ :style
                         {} (:overflow :auto) (:min-width "\"12%")
-                      , &
-                      ->> defs (set->list) (sort compare-string)
+                      , & $ ->> defs (set->list) (sort compare-string)
                         map $ fn (name)
                           div
                             {} (:class-name "\"hover-item")
-                              :style $ merge ({} $ :padding "\"0 8px")
+                              :style $ merge
+                                {} $ :padding "\"0 8px"
                                 if (= name selected)
                                   {} $ :background-color (hsl 0 0 95)
-                              :on-click $ fn (e d!) (d! cursor $ assoc state :selected name)
+                              :on-click $ fn (e d!)
+                                d! cursor $ assoc state :selected name
                             <> name
-                    div ({} $ :style ui/expand)
+                    div
+                      {} $ :style ui/expand
                       let
                           declaration $ get-in file ([] "\"defs" selected)
                         if (calcit-fn? declaration) (comp-fn declaration) (comp-code declaration false)
                 =< nil 8
                 comp-imports $ get file "\"import"
+        |comp-preview $ quote
+          defcomp comp-preview (data)
+            if (some? data)
+              div
+                {} $ :style
+                  {} (:position :absolute) (:bottom 0) (:right 0)
+                    :background-color $ hsl 0 0 100 0.6
+                    :font-family ui/font-code
+                    :white-space :pre
+                    :border $ str "\"1px solid " (hsl 0 0 90)
+                    :font-size 12
+                    :line-height "\"20px"
+                    :padding 8
+                div $ {}
+                  :innerText $ trim (write-cirru-edn data)
+                div $ {} (:inner-text "\"×")
+                  :style $ {} (:position :absolute) (:top 4) (:right 4)
+                    :color $ hsl 0 80 60
+                    :cursor :pointer
+                    :font-size 14
+                  :on-click $ fn (e d!) (d! :preview nil)
+              div $ {}
         |comp-fn $ quote
           defcomp comp-fn (f)
             div ({})
               div ({})
                 <> $ str "\"Name: " (get f "\"ns") "\"/" (get f "\"name")
-              div ({}) (<> $ str "\"Args:")
+              div ({})
+                <> $ str "\"Args:"
                 comp-code (get f "\"args") false
-              div ({}) (<> $ str "\"Code:")
+              div ({})
+                <> $ str "\"Code:"
                 comp-code (get f "\"code") false
         |calcit-proc? $ quote
           defn calcit-proc? (x)
-            and (map? x) (= "\"proc" $ get x "\"kind")
+            and (map? x)
+              = "\"proc" $ get x "\"kind"
         |comp-imports $ quote
           defcomp comp-imports (imports)
             div
@@ -58,14 +95,14 @@
                   :max-height "\"20%"
                   :overflow :auto
                   :padding "\"0 8px"
-              , &
-              ->> imports (to-pairs) (set->list)
+              , & $ ->> imports (to-pairs) (set->list)
                 map $ fn (pair)
                   let[] (name info) pair $ div
                     {} $ :style
                       merge ui/row $ {} (:line-height "\"1.6")
                     div
-                      {} $ :style ({} $ :min-width "\"12%")
+                      {} $ :style
+                        {} $ :min-width "\"12%"
                       <> name
                     div
                       {} $ :style
@@ -89,53 +126,68 @@
                           every? calcit-symbol? expr
                         {} $ :display :inline-block
                       if last? $ {} (:display :inline-block)
-                  , &
-                  let
+                  , & $ let
                       size $ count expr
                     map-indexed
                       fn (idx x)
                         comp-code x $ = (inc idx) size
                       , expr
-              (calcit-symbol? expr)
-                comp-symbol expr
+              (calcit-symbol? expr) (comp-symbol expr)
               (calcit-proc? expr)
-                <> "\"Proc" $ {} (:color $ hsl 0 80 50) (:margin "\"0 4px") (:white-space :pre-line) (:display :inline-block)
+                <> "\"Proc" $ {}
+                  :color $ hsl 0 80 50
+                  :margin "\"0 4px"
+                  :white-space :pre-line
+                  :display :inline-block
               (calcit-keyword? expr)
-                <> (str "\":" $ get expr "\"val")
-                  {} (:color $ hsl 200 80 40) (:margin "\"0 4px") (:white-space :pre-line) (:display :inline-block)
+                <>
+                  str "\":" $ get expr "\"val"
+                  {}
+                    :color $ hsl 200 80 40
+                    :margin "\"0 4px"
+                    :white-space :pre-line
+                    :display :inline-block
               true $ <> (escape expr)
-                {} (:color $ hsl 200 80 60) (:margin "\"0 4px") (:white-space :pre) (:display :inline-block)
+                {}
+                  :color $ hsl 200 80 60
+                  :margin "\"0 4px"
+                  :white-space :pre
+                  :display :inline-block
         |comp-container $ quote
           defcomp comp-container (reel)
             let
                 store $ :store reel
                 states $ :states store
                 cursor $ either (:cursor states) ([])
-                state $ either (:data states) ({} $ :selected nil)
+                state $ either (:data states)
+                  {} $ :selected nil
               div
                 {} $ :style (merge ui/global ui/fullscreen ui/column)
                 memof-call comp-header
                 div
                   {} $ :style (merge ui/expand ui/row)
                   let
-                      ns-names $ if (some-in? store $ [] :ir "\"files")
+                      ns-names $ if
+                        some-in? store $ [] :ir "\"files"
                         keys $ get-in store ([] :ir "\"files")
                         #{}
                     div
                       {} $ :style
                         {} (:padding "\"8 0px") (:width "\"20%") (:overflow :auto)
                           :border-right $ str "\"1px solid " (hsl 0 0 90)
-                      , &
-                      if (empty? ns-names)
+                      , & $ if (empty? ns-names)
                         [] $ div ({})
                           <> "\"No namespaces" $ {} (:font-family ui/font-fancy)
                         ->> ns-names (set->list) (sort compare-string)
                           map $ fn (name)
                             div
                               {}
-                                :on-click $ fn (e d!) (d! cursor $ assoc state :selected name)
-                                :style $ merge ({} $ :padding "\"0 8px")
-                                  if (= name $ :selected state)
+                                :on-click $ fn (e d!)
+                                  d! cursor $ assoc state :selected name
+                                :style $ merge
+                                  {} $ :padding "\"0 8px"
+                                  if
+                                    = name $ :selected state
                                     {} $ :background-color (hsl 0 0 94)
                                 :class-name "\"hover-item"
                               <> name
@@ -143,25 +195,29 @@
                       selected $ :selected state
                       has-file? $ some-in? store ([] :ir "\"files" selected)
                     if has-file?
-                      comp-file (>> states selected) (get-in store $ [] :ir "\"files" selected)
-                      div ({} $ :style ui/expand) (<> $ str "\"No file slected: " selected)
+                      comp-file (>> states selected)
+                        get-in store $ [] :ir "\"files" selected
+                      div
+                        {} $ :style ui/expand
+                        <> $ str "\"No file slected: " selected
+                comp-preview $ :preview store
                 when dev? $ comp-reel (>> states :reel) reel ({})
         |comp-header $ quote
-          defcomp comp-header ()
-            div
-              {} $ :style
-                {}
-                  :border-bottom $ str "\"1px solid " (hsl 0 0 90)
-                  :padding 8
-              input $ {} (:type "\"file") (:accept "\"application/json")
-                :on-change $ fn (e d!)
-                  let
-                      file $ -> (:event e) .-target .-files (aget 0)
-                      fr $ "js/new FileReader"
-                    -> (:event e) .-target $ aset "\"value" nil
-                    aset fr "\"onload" $ fn (event)
-                      d! :ir-data $ to-calcit-data (js/JSON.parse $ -> event .-target .-result)
-                    .readAsText fr file
+          defcomp comp-header () $ div
+            {} $ :style
+              {}
+                :border-bottom $ str "\"1px solid " (hsl 0 0 90)
+                :padding 8
+            input $ {} (:type "\"file") (:accept "\"application/json")
+              :on-change $ fn (e d!)
+                let
+                    file $ -> (:event e) .-target .-files (aget 0)
+                    fr $ "js/new FileReader"
+                  -> (:event e) .-target $ aset "\"value" nil
+                  aset fr "\"onload" $ fn (event)
+                    d! :ir-data $ to-calcit-data
+                      js/JSON.parse $ -> event .-target .-result
+                  .readAsText fr file
         |comp-symbol $ quote
           defcomp comp-symbol (expr)
             let
@@ -170,23 +226,38 @@
                 {} $ :style
                   merge ui/column $ {} (:display :inline-flex) (:margin "\"0px 4px") (:padding "\"0 4px") (:line-height "\"1.2")
                 div
-                  {} $ :style ({} $ :display :inline-block)
-                  <> $ get expr "\"val"
+                  {}
+                    :style $ merge
+                      {} $ :display :inline-block
+                    :on-click $ fn (e d!) (d! :preview expr)
+                  <> (get expr "\"val")
+                    case-default
+                      -> expr (get "\"resolved") (get "\"kind")
+                      , nil
+                      "\"resolvedLocal" $ {}
+                        :color $ hsl 200 80 70
+                      "\"notResolved" $ {}
+                        :color $ hsl 150 80 70
                 div ({})
                   <> (get expr "\"ns")
-                    {} (:font-size 8) (:color $ hsl 0 0 80) (:font-family ui/font-normal)
+                    {} (:font-size 8)
+                      :color $ hsl 0 0 80
+                      :font-family ui/font-normal
                   =< 4 nil
                   if
                     /= (get expr "\"ns") resolved-ns
                     span $ {}
-                      :style $ {} (:font-size "\"8px") (:white-space :nowrap) (:font-family ui/font-normal) (:color $ hsl 0 80 70)
+                      :style $ {} (:font-size "\"8px") (:white-space :nowrap) (:font-family ui/font-normal)
+                        :color $ hsl 0 80 70
                       :inner-text resolved-ns
         |calcit-keyword? $ quote
           defn calcit-keyword? (x)
-            and (map? x) (= "\"keyword" $ get x "\"kind")
+            and (map? x)
+              = "\"keyword" $ get x "\"kind"
         |calcit-symbol? $ quote
           defn calcit-symbol? (x)
-            and (map? x) (= "\"symbol" $ get x "\"kind")
+            and (map? x)
+              = "\"symbol" $ get x "\"kind"
       :proc $ quote ()
     |app.config $ {}
       :ns $ quote (ns app.config)
@@ -195,8 +266,7 @@
           def cdn? $ cond
               exists? js/window
               , false
-            (exists? js/process)
-              = "\"true" js/process.env.cdn
+            (exists? js/process) (= "\"true" js/process.env.cdn)
             :else false
         |dev? $ quote (def dev? true)
         |site $ quote
@@ -204,7 +274,15 @@
       :proc $ quote ()
     |app.main $ {}
       :ns $ quote
-        ns app.main $ :require ([] respo.core :refer $ [] render! clear-cache! realize-ssr!) ([] app.comp.container :refer $ [] comp-container) ([] app.updater :refer $ [] updater) ([] app.schema :as schema) ([] reel.util :refer $ [] listen-devtools!) ([] reel.core :refer $ [] reel-updater refresh-reel) ([] reel.schema :as reel-schema) ([] app.config :as config)
+        ns app.main $ :require
+          [] respo.core :refer $ [] render! clear-cache! realize-ssr!
+          [] app.comp.container :refer $ [] comp-container
+          [] app.updater :refer $ [] updater
+          [] app.schema :as schema
+          [] reel.util :refer $ [] listen-devtools!
+          [] reel.core :refer $ [] reel-updater refresh-reel
+          [] reel.schema :as reel-schema
+          [] app.config :as config
       :defs $ {}
         |ssr? $ quote
           def ssr? $ some? (js/document.querySelector |meta.respo-ssr)
@@ -216,10 +294,15 @@
               * 1000 duration
         |dispatch! $ quote
           defn dispatch! (op op-data)
-            when (and config/dev? $ not= op :states) (println "\"Dispatch:" op)
+            when
+              and config/dev? $ not= op :states
+              println "\"Dispatch:" op
             reset! *reel $ reel-updater updater @*reel op op-data
         |main! $ quote
-          defn main! () (println "\"Running mode:" $ if config/dev? "\"dev" "\"release") (if ssr? $ render-app! realize-ssr!) (render-app! render!)
+          defn main! () (load-console-formatter!)
+            println "\"Running mode:" $ if config/dev? "\"dev" "\"release"
+            if ssr? $ render-app! realize-ssr!
+            render-app! render!
             add-watch *reel :changes $ fn (reel prev) (render-app! render!)
             listen-devtools! |a dispatch!
             .addEventListener js/window |beforeunload $ fn (event) (persist-storage!)
@@ -230,13 +313,12 @@
                 dispatch! :hydrate-storage $ extract-cirru-edn (js/JSON.parse raw)
             println "|App started."
         |persist-storage! $ quote
-          defn persist-storage! ()
-            .setItem js/localStorage (:storage-key config/site)
-              js/JSON.stringify $ to-cirru-edn (:store @*reel)
+          defn persist-storage! () $ .setItem js/localStorage (:storage-key config/site)
+            js/JSON.stringify $ to-cirru-edn (:store @*reel)
         |*reel $ quote
           defatom *reel $ -> reel-schema/reel (assoc :base schema/store) (assoc :store schema/store)
         |snippets $ quote
-          defn snippets () (println config/cdn?)
+          defn snippets () $ println config/cdn?
         |render-app! $ quote
           defn render-app! (renderer)
             renderer mount-target (comp-container @*reel) (\ dispatch! % %2)
@@ -244,21 +326,30 @@
           defn reload! () (clear-cache!) (remove-watch *reel :changes)
             add-watch *reel :changes $ fn (reel prev) (render-app! render!)
             reset! *reel $ refresh-reel @*reel schema/store updater
-        |mount-target $ quote (def mount-target $ .querySelector js/document |.app)
+        |mount-target $ quote
+          def mount-target $ .querySelector js/document |.app
       :proc $ quote ()
     |app.schema $ {}
       :ns $ quote (ns app.schema)
       :defs $ {}
         |store $ quote
           def store $ {}
-            :states $ {} (:cursor $ [])
+            :states $ {}
+              :cursor $ []
             :ir-data nil
+            :preview nil
       :proc $ quote ()
     |app.updater $ {}
       :ns $ quote
-        ns app.updater $ :require ([] respo.cursor :refer $ [] update-states)
+        ns app.updater $ :require
+          [] respo.cursor :refer $ [] update-states
       :defs $ {}
         |updater $ quote
           defn updater (store op data op-id op-time)
-            case op (:states $ update-states store data) (:ir-data $ assoc store :ir data) (:hydrate-storage data) (op store)
+            case op
+              :states $ update-states store data
+              :ir-data $ assoc store :ir data
+              :preview $ assoc store :preview data
+              :hydrate-storage data
+              op store
       :proc $ quote ()

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.2.54"
+    "@calcit/procs": "^0.2.95"
   },
   "devDependencies": {
-    "vite": "^2.0.0-beta.62"
+    "vite": "^2.0.5"
   },
   "version": "0.0.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,43 +2,44 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.2.54":
-  version "0.2.54"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.2.54.tgz#24e2343d37ad75637f687ba7f6f610a82aa3c5a8"
-  integrity sha512-qGjDySf/X1wR04ecvUxzulu3N6GS73gpHV8UI8IapwIigot1RH7QXX56SvMgLsAoTCZNldWND7PxR5GoLdLhbQ==
+"@calcit/procs@^0.2.95":
+  version "0.2.95"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.2.95.tgz#f86b272a582ed31cf1f6f33d0cbc67b1d0c6f1b2"
+  integrity sha512-DlX9EdYETbdK1x2XDA5f0U8tAy8TdIKjf+BYW5TZqYBBHJ2B2xRtid8dWIDE8Vk1Ha0XKBxEJUVXCJVoAjO7jQ==
   dependencies:
-    "@calcit/ternary-tree" "0.0.7"
+    "@calcit/ternary-tree" "0.0.12"
     "@cirru/parser.ts" "^0.0.1"
+    "@cirru/writer.ts" "^0.1.2"
 
-"@calcit/ternary-tree@0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@calcit/ternary-tree/-/ternary-tree-0.0.7.tgz#ae41e3b02cc51f6ff08aa11c7db4cbd4c55440d5"
-  integrity sha512-7MCgpJ36yVvObQYE+budozGLtvHzZU50bh3PyCa2j/B9fcpdRaDESyrZu7DEPaaE+FDAS/ivAzNIXKLBPImqug==
+"@calcit/ternary-tree@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@calcit/ternary-tree/-/ternary-tree-0.0.12.tgz#30f33a61e713f48e338b9fd3fd5ad9eabf3d1bdd"
+  integrity sha512-rouLsMVOEvposSCkYCWrbL6zEk7k9Z1cX23+Fe1wzjBYL0eqZIknwvzMOGnOoPyXuiPk1laM5mSFgOxd25cH4Q==
 
 "@cirru/parser.ts@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@cirru/parser.ts/-/parser.ts-0.0.1.tgz#0870b051bd9f56626759ec22d7a0d5c51b19fe9c"
   integrity sha512-FlUWZ2VqIUK/5cG926CVw9fQ7IGQzRDz8NL2Zc1lK2NyvOltAyZEDxxj/ztWjGOOnetVtM5mDx8rsbsr/SLYhg==
 
-colorette@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
-  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+"@cirru/writer.ts@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.2.tgz#1fa667c2fbdcf083901654b771ed40879d2998e1"
+  integrity sha512-TU1uNk6ei+qsaEY7w9kHyGrAoAYkfDjZu5XyHUjb4i4UvAC+c5EHeA6rVPQL7IhIeFJeFgrnBNb7LizduzWpgA==
 
-esbuild@^0.8.34:
-  version "0.8.39"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.39.tgz#18b84a3d56173c55ee8f45bc6c7b5374b0a98ecb"
-  integrity sha512-/do5H74a5ChyeKRWfkDh3EpICXpsz6dWTtFFbotb7BlIHvWqnRrZYDb8IBubOHdEtKzuiksilRO19aBtp3/HHQ==
+colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+esbuild@^0.8.52:
+  version "0.8.57"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.57.tgz#a42d02bc2b57c70bcd0ef897fe244766bb6dd926"
+  integrity sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==
 
 fsevents@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
-  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -52,7 +53,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-is-core-module@^2.1.0:
+is-core-module@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
@@ -70,26 +71,26 @@ path-parse@^1.0.6:
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 postcss@^8.2.1:
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.4.tgz#20a98a39cf303d15129c2865a9ec37eda0031d04"
-  integrity sha512-kRFftRoExRVXZlwUuay9iC824qmXPcQQVzAjbCCgjpXnkdMCJYBu2gTwAaFBzv8ewND6O8xFb3aELmEkh9zTzg==
+  version "8.2.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.8.tgz#0b90f9382efda424c4f0f69a2ead6f6830d08ece"
+  integrity sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==
   dependencies:
-    colorette "^1.2.1"
+    colorette "^1.2.2"
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
 resolve@^1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
-  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
-    is-core-module "^2.1.0"
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-rollup@^2.35.1:
-  version "2.38.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.38.4.tgz#1b84ea8728c73b1a00a6a6e9c630ec8c3fe48cea"
-  integrity sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==
+rollup@^2.38.5:
+  version "2.41.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.1.tgz#c7c7ada42b13be505facd516f13fb697c24c1116"
+  integrity sha512-nepLFAW5W71/MWpS2Yr7r31eS7HRfYg2RXnxb6ehqN9zY42yACxKtEfb4xq8SmNfUohAzGMcyl6jkwdLOAiUbg==
   optionalDependencies:
     fsevents "~2.3.1"
 
@@ -98,14 +99,14 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-vite@^2.0.0-beta.62:
-  version "2.0.0-beta.62"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.0.0-beta.62.tgz#3227fc63ecd3d6fc67b1b95add68cdcde09844b2"
-  integrity sha512-75RF5H/8Ta2UvTSjiK5EslyTkUTgRMgkeVRDHqlfDNAJUI8+gvXzhEdTpq2bsASjvnlSytBk+odtCxikEoibbg==
+vite@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.0.5.tgz#ac46857a3fa8686d077921e61bd48a986931df1d"
+  integrity sha512-QTgEDbq1WsTtr6j+++ewjhBFEk6c8v0xz4fb/OWJQKNYU8ZZtphOshwOqAlnarSstPBtWCBR0tsugXx6ajfoUg==
   dependencies:
-    esbuild "^0.8.34"
+    esbuild "^0.8.52"
     postcss "^8.2.1"
     resolve "^1.19.0"
-    rollup "^2.35.1"
+    rollup "^2.38.5"
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"


### PR DESCRIPTION
Made this change since some more symbol information is attached to the AST file in https://github.com/calcit-lang/calcit-runner/pull/209 .

Also added a tip card for displaying detais:

![image](https://user-images.githubusercontent.com/449224/110753344-6f9ec400-8281-11eb-964f-7059a4dbb7d5.png)
