### PR TITLE
chore: migrate to Calcit 0.13.33

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -22,22 +22,24 @@ jobs:
         corepack prepare yarn@4.12.0 --activate
         yarn --version
 
-    - uses: calcit-lang/setup-cr@0.0.9
+    - uses: calcit-lang/setup-calcit@v1.3.0
+      with:
+        tools: calcit,caps
 
     - name: Validate Calcit snapshot and type baseline
       run: |
         caps --ci
         yarn install --immutable
-        cr calcit.cirru edit format
+        calcit calcit.cirru edit format
         git diff --exit-code -- calcit.cirru
-        cr calcit.cirru --check-only
-        cr calcit.cirru analyze check-types --summary-only --format json
-        cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
-        cr calcit.cirru analyze deprecated --summary-only --format json
+        calcit calcit.cirru --check-only
+        calcit calcit.cirru analyze check-types --summary-only --format json
+        calcit calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
+        calcit calcit.cirru analyze deprecated --summary-only --format json
 
     - name: "compiles to js"
       run: >
-        cr calcit.cirru js
+        calcit calcit.cirru js
         && yarn vite build --base=./
 
     - name: Deploy to server

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -28,7 +28,7 @@ const RAW_RUNTIME_STATE =
       [null, {\
         "packageLocation": "./",\
         "packageDependencies": [\
-          ["@calcit/procs", "npm:0.12.11"],\
+          ["@calcit/procs", "npm:0.13.33"],\
           ["bottom-tip", "npm:0.1.5"],\
           ["cirru-color", "npm:0.2.4"],\
           ["copy-text-to-clipboard", "npm:3.2.2"],\
@@ -40,29 +40,29 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@calcit/procs", [\
-      ["npm:0.12.11", {\
-        "packageLocation": "../../../.yarn/berry/cache/@calcit-procs-npm-0.12.11-cac67703ce-10c0.zip/node_modules/@calcit/procs/",\
+      ["npm:0.13.33", {\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@calcit-procs-npm-0.13.33-caa508f3e6-10c0.zip/node_modules/@calcit/procs/",\
         "packageDependencies": [\
-          ["@calcit/procs", "npm:0.12.11"],\
-          ["@calcit/ternary-tree", "npm:0.0.25"],\
+          ["@calcit/procs", "npm:0.13.33"],\
+          ["@calcit/ternary-tree", "npm:0.0.26"],\
           ["@cirru/parser.ts", "npm:0.0.9"],\
-          ["@cirru/writer.ts", "npm:0.1.7"]\
+          ["@cirru/writer.ts", "npm:0.1.9"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@calcit/ternary-tree", [\
-      ["npm:0.0.25", {\
-        "packageLocation": "../../../.yarn/berry/cache/@calcit-ternary-tree-npm-0.0.25-9fe008f777-10c0.zip/node_modules/@calcit/ternary-tree/",\
+      ["npm:0.0.26", {\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@calcit-ternary-tree-npm-0.0.26-842160961c-10c0.zip/node_modules/@calcit/ternary-tree/",\
         "packageDependencies": [\
-          ["@calcit/ternary-tree", "npm:0.0.25"]\
+          ["@calcit/ternary-tree", "npm:0.0.26"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@cirru/parser.ts", [\
       ["npm:0.0.9", {\
-        "packageLocation": "../../../.yarn/berry/cache/@cirru-parser.ts-npm-0.0.9-d7e6fe396b-10c0.zip/node_modules/@cirru/parser.ts/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@cirru-parser.ts-npm-0.0.9-d7e6fe396b-10c0.zip/node_modules/@cirru/parser.ts/",\
         "packageDependencies": [\
           ["@cirru/parser.ts", "npm:0.0.9"]\
         ],\
@@ -70,17 +70,17 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@cirru/writer.ts", [\
-      ["npm:0.1.7", {\
-        "packageLocation": "../../../.yarn/berry/cache/@cirru-writer.ts-npm-0.1.7-8af4bd8836-10c0.zip/node_modules/@cirru/writer.ts/",\
+      ["npm:0.1.9", {\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@cirru-writer.ts-npm-0.1.9-6e0d3d3bb3-10c0.zip/node_modules/@cirru/writer.ts/",\
         "packageDependencies": [\
-          ["@cirru/writer.ts", "npm:0.1.7"]\
+          ["@cirru/writer.ts", "npm:0.1.9"]\
         ],\
         "linkType": "HARD"\
       }]\
     ]],\
     ["@emnapi/core", [\
       ["npm:1.8.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/@emnapi-core-npm-1.8.1-9be0a25589-10c0.zip/node_modules/@emnapi/core/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@emnapi-core-npm-1.8.1-9be0a25589-10c0.zip/node_modules/@emnapi/core/",\
         "packageDependencies": [\
           ["@emnapi/core", "npm:1.8.1"],\
           ["@emnapi/wasi-threads", "npm:1.1.0"],\
@@ -91,7 +91,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@emnapi/runtime", [\
       ["npm:1.8.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/@emnapi-runtime-npm-1.8.1-1ce27dc028-10c0.zip/node_modules/@emnapi/runtime/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@emnapi-runtime-npm-1.8.1-1ce27dc028-10c0.zip/node_modules/@emnapi/runtime/",\
         "packageDependencies": [\
           ["@emnapi/runtime", "npm:1.8.1"],\
           ["tslib", "npm:2.8.1"]\
@@ -101,7 +101,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@emnapi/wasi-threads", [\
       ["npm:1.1.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/@emnapi-wasi-threads-npm-1.1.0-4dc2c60138-10c0.zip/node_modules/@emnapi/wasi-threads/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@emnapi-wasi-threads-npm-1.1.0-4dc2c60138-10c0.zip/node_modules/@emnapi/wasi-threads/",\
         "packageDependencies": [\
           ["@emnapi/wasi-threads", "npm:1.1.0"],\
           ["tslib", "npm:2.8.1"]\
@@ -111,7 +111,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@isaacs/balanced-match", [\
       ["npm:4.0.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/@isaacs-balanced-match-npm-4.0.1-8965afafe6-10c0.zip/node_modules/@isaacs/balanced-match/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@isaacs-balanced-match-npm-4.0.1-8965afafe6-10c0.zip/node_modules/@isaacs/balanced-match/",\
         "packageDependencies": [\
           ["@isaacs/balanced-match", "npm:4.0.1"]\
         ],\
@@ -120,7 +120,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@isaacs/brace-expansion", [\
       ["npm:5.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/@isaacs-brace-expansion-npm-5.0.0-754d3cb3f5-10c0.zip/node_modules/@isaacs/brace-expansion/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@isaacs-brace-expansion-npm-5.0.0-754d3cb3f5-10c0.zip/node_modules/@isaacs/brace-expansion/",\
         "packageDependencies": [\
           ["@isaacs/balanced-match", "npm:4.0.1"],\
           ["@isaacs/brace-expansion", "npm:5.0.0"]\
@@ -130,7 +130,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@isaacs/fs-minipass", [\
       ["npm:4.0.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/@isaacs-fs-minipass-npm-4.0.1-677026e841-10c0.zip/node_modules/@isaacs/fs-minipass/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@isaacs-fs-minipass-npm-4.0.1-677026e841-10c0.zip/node_modules/@isaacs/fs-minipass/",\
         "packageDependencies": [\
           ["@isaacs/fs-minipass", "npm:4.0.1"],\
           ["minipass", "npm:7.1.2"]\
@@ -140,7 +140,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@napi-rs/wasm-runtime", [\
       ["npm:1.1.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/@napi-rs-wasm-runtime-npm-1.1.1-c9debf141f-10c0.zip/node_modules/@napi-rs/wasm-runtime/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@napi-rs-wasm-runtime-npm-1.1.1-c9debf141f-10c0.zip/node_modules/@napi-rs/wasm-runtime/",\
         "packageDependencies": [\
           ["@emnapi/core", "npm:1.8.1"],\
           ["@emnapi/runtime", "npm:1.8.1"],\
@@ -152,7 +152,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@npmcli/agent", [\
       ["npm:4.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/@npmcli-agent-npm-4.0.0-502e5ae4f0-10c0.zip/node_modules/@npmcli/agent/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@npmcli-agent-npm-4.0.0-502e5ae4f0-10c0.zip/node_modules/@npmcli/agent/",\
         "packageDependencies": [\
           ["@npmcli/agent", "npm:4.0.0"],\
           ["agent-base", "npm:7.1.4"],\
@@ -166,7 +166,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@npmcli/fs", [\
       ["npm:5.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/@npmcli-fs-npm-5.0.0-9d737ae2f3-10c0.zip/node_modules/@npmcli/fs/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@npmcli-fs-npm-5.0.0-9d737ae2f3-10c0.zip/node_modules/@npmcli/fs/",\
         "packageDependencies": [\
           ["@npmcli/fs", "npm:5.0.0"],\
           ["semver", "npm:7.7.3"]\
@@ -176,7 +176,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@oxc-project/runtime", [\
       ["npm:0.115.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/@oxc-project-runtime-npm-0.115.0-6e2d8836fb-10c0.zip/node_modules/@oxc-project/runtime/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@oxc-project-runtime-npm-0.115.0-6e2d8836fb-10c0.zip/node_modules/@oxc-project/runtime/",\
         "packageDependencies": [\
           ["@oxc-project/runtime", "npm:0.115.0"]\
         ],\
@@ -185,7 +185,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@oxc-project/types", [\
       ["npm:0.115.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/@oxc-project-types-npm-0.115.0-a8db858ee0-10c0.zip/node_modules/@oxc-project/types/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@oxc-project-types-npm-0.115.0-a8db858ee0-10c0.zip/node_modules/@oxc-project/types/",\
         "packageDependencies": [\
           ["@oxc-project/types", "npm:0.115.0"]\
         ],\
@@ -312,7 +312,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@rolldown/pluginutils", [\
       ["npm:1.0.0-rc.6", {\
-        "packageLocation": "../../../.yarn/berry/cache/@rolldown-pluginutils-npm-1.0.0-rc.6-f6d3733c9d-10c0.zip/node_modules/@rolldown/pluginutils/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@rolldown-pluginutils-npm-1.0.0-rc.6-f6d3733c9d-10c0.zip/node_modules/@rolldown/pluginutils/",\
         "packageDependencies": [\
           ["@rolldown/pluginutils", "npm:1.0.0-rc.6"]\
         ],\
@@ -321,7 +321,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["@tybys/wasm-util", [\
       ["npm:0.10.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/@tybys-wasm-util-npm-0.10.1-607c8a7e5c-10c0.zip/node_modules/@tybys/wasm-util/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/@tybys-wasm-util-npm-0.10.1-607c8a7e5c-10c0.zip/node_modules/@tybys/wasm-util/",\
         "packageDependencies": [\
           ["@tybys/wasm-util", "npm:0.10.1"],\
           ["tslib", "npm:2.8.1"]\
@@ -331,7 +331,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["abbrev", [\
       ["npm:4.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/abbrev-npm-4.0.0-7d848a1ef0-10c0.zip/node_modules/abbrev/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/abbrev-npm-4.0.0-7d848a1ef0-10c0.zip/node_modules/abbrev/",\
         "packageDependencies": [\
           ["abbrev", "npm:4.0.0"]\
         ],\
@@ -340,7 +340,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["agent-base", [\
       ["npm:7.1.4", {\
-        "packageLocation": "../../../.yarn/berry/cache/agent-base-npm-7.1.4-cb8b4604d5-10c0.zip/node_modules/agent-base/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/agent-base-npm-7.1.4-cb8b4604d5-10c0.zip/node_modules/agent-base/",\
         "packageDependencies": [\
           ["agent-base", "npm:7.1.4"]\
         ],\
@@ -349,7 +349,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["bottom-tip", [\
       ["npm:0.1.5", {\
-        "packageLocation": "../../../.yarn/berry/cache/bottom-tip-npm-0.1.5-a08d7463a4-10c0.zip/node_modules/bottom-tip/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/bottom-tip-npm-0.1.5-a08d7463a4-10c0.zip/node_modules/bottom-tip/",\
         "packageDependencies": [\
           ["bottom-tip", "npm:0.1.5"],\
           ["nanoid", "npm:4.0.2"],\
@@ -360,7 +360,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["browser-split", [\
       ["npm:0.0.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/browser-split-npm-0.0.1-3bb65062e4-10c0.zip/node_modules/browser-split/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/browser-split-npm-0.0.1-3bb65062e4-10c0.zip/node_modules/browser-split/",\
         "packageDependencies": [\
           ["browser-split", "npm:0.0.1"]\
         ],\
@@ -369,7 +369,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["cacache", [\
       ["npm:20.0.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/cacache-npm-20.0.3-5f244d5bdd-10c0.zip/node_modules/cacache/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/cacache-npm-20.0.3-5f244d5bdd-10c0.zip/node_modules/cacache/",\
         "packageDependencies": [\
           ["@npmcli/fs", "npm:5.0.0"],\
           ["cacache", "npm:20.0.3"],\
@@ -389,7 +389,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["camelize", [\
       ["npm:1.0.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/camelize-npm-1.0.1-d86ebe085a-10c0.zip/node_modules/camelize/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/camelize-npm-1.0.1-d86ebe085a-10c0.zip/node_modules/camelize/",\
         "packageDependencies": [\
           ["camelize", "npm:1.0.1"]\
         ],\
@@ -398,7 +398,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["chownr", [\
       ["npm:3.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/chownr-npm-3.0.0-5275e85d25-10c0.zip/node_modules/chownr/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/chownr-npm-3.0.0-5275e85d25-10c0.zip/node_modules/chownr/",\
         "packageDependencies": [\
           ["chownr", "npm:3.0.0"]\
         ],\
@@ -407,7 +407,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["cirru-color", [\
       ["npm:0.2.4", {\
-        "packageLocation": "../../../.yarn/berry/cache/cirru-color-npm-0.2.4-703bd8209e-10c0.zip/node_modules/cirru-color/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/cirru-color-npm-0.2.4-703bd8209e-10c0.zip/node_modules/cirru-color/",\
         "packageDependencies": [\
           ["cirru-color", "npm:0.2.4"]\
         ],\
@@ -416,7 +416,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["copy-text-to-clipboard", [\
       ["npm:3.2.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/copy-text-to-clipboard-npm-3.2.2-a4142785c3-10c0.zip/node_modules/copy-text-to-clipboard/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/copy-text-to-clipboard-npm-3.2.2-a4142785c3-10c0.zip/node_modules/copy-text-to-clipboard/",\
         "packageDependencies": [\
           ["copy-text-to-clipboard", "npm:3.2.2"]\
         ],\
@@ -425,7 +425,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["dayjs", [\
       ["npm:1.11.20", {\
-        "packageLocation": "../../../.yarn/berry/cache/dayjs-npm-1.11.20-98d80a1c92-10c0.zip/node_modules/dayjs/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/dayjs-npm-1.11.20-98d80a1c92-10c0.zip/node_modules/dayjs/",\
         "packageDependencies": [\
           ["dayjs", "npm:1.11.20"]\
         ],\
@@ -434,14 +434,14 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["debug", [\
       ["npm:4.4.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/debug-npm-4.4.3-0105c6123a-10c0.zip/node_modules/debug/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/debug-npm-4.4.3-0105c6123a-10c0.zip/node_modules/debug/",\
         "packageDependencies": [\
           ["debug", "npm:4.4.3"]\
         ],\
         "linkType": "SOFT"\
       }],\
       ["virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3", {\
-        "packageLocation": "./.yarn/__virtual__/debug-virtual-5da9fc757d/4/.yarn/berry/cache/debug-npm-4.4.3-0105c6123a-10c0.zip/node_modules/debug/",\
+        "packageLocation": "./.yarn/__virtual__/debug-virtual-5da9fc757d/4/Users/chenyong/.yarn/berry/cache/debug-npm-4.4.3-0105c6123a-10c0.zip/node_modules/debug/",\
         "packageDependencies": [\
           ["@types/supports-color", null],\
           ["debug", "virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3"],\
@@ -457,7 +457,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["detect-libc", [\
       ["npm:2.1.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/detect-libc-npm-2.1.2-d0c382b1e2-10c0.zip/node_modules/detect-libc/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/detect-libc-npm-2.1.2-d0c382b1e2-10c0.zip/node_modules/detect-libc/",\
         "packageDependencies": [\
           ["detect-libc", "npm:2.1.2"]\
         ],\
@@ -466,7 +466,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["dom-walk", [\
       ["npm:0.1.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/dom-walk-npm-0.1.2-7d20a1a8d8-10c0.zip/node_modules/dom-walk/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/dom-walk-npm-0.1.2-7d20a1a8d8-10c0.zip/node_modules/dom-walk/",\
         "packageDependencies": [\
           ["dom-walk", "npm:0.1.2"]\
         ],\
@@ -475,7 +475,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["encoding", [\
       ["npm:0.1.13", {\
-        "packageLocation": "../../../.yarn/berry/cache/encoding-npm-0.1.13-82a1837d30-10c0.zip/node_modules/encoding/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/encoding-npm-0.1.13-82a1837d30-10c0.zip/node_modules/encoding/",\
         "packageDependencies": [\
           ["encoding", "npm:0.1.13"],\
           ["iconv-lite", "npm:0.6.3"]\
@@ -485,7 +485,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["env-paths", [\
       ["npm:2.2.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/env-paths-npm-2.2.1-7c7577428c-10c0.zip/node_modules/env-paths/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/env-paths-npm-2.2.1-7c7577428c-10c0.zip/node_modules/env-paths/",\
         "packageDependencies": [\
           ["env-paths", "npm:2.2.1"]\
         ],\
@@ -494,7 +494,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["err-code", [\
       ["npm:2.0.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/err-code-npm-2.0.3-082e0ff9a7-10c0.zip/node_modules/err-code/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/err-code-npm-2.0.3-082e0ff9a7-10c0.zip/node_modules/err-code/",\
         "packageDependencies": [\
           ["err-code", "npm:2.0.3"]\
         ],\
@@ -503,7 +503,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["error", [\
       ["npm:4.4.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/error-npm-4.4.0-dc2d401d15-10c0.zip/node_modules/error/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/error-npm-4.4.0-dc2d401d15-10c0.zip/node_modules/error/",\
         "packageDependencies": [\
           ["camelize", "npm:1.0.1"],\
           ["error", "npm:4.4.0"],\
@@ -515,7 +515,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["ev-store", [\
       ["npm:7.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/ev-store-npm-7.0.0-1ae84fd275-10c0.zip/node_modules/ev-store/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/ev-store-npm-7.0.0-1ae84fd275-10c0.zip/node_modules/ev-store/",\
         "packageDependencies": [\
           ["ev-store", "npm:7.0.0"],\
           ["individual", "npm:3.0.0"]\
@@ -525,7 +525,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["exponential-backoff", [\
       ["npm:3.1.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/exponential-backoff-npm-3.1.3-28be78d98e-10c0.zip/node_modules/exponential-backoff/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/exponential-backoff-npm-3.1.3-28be78d98e-10c0.zip/node_modules/exponential-backoff/",\
         "packageDependencies": [\
           ["exponential-backoff", "npm:3.1.3"]\
         ],\
@@ -534,14 +534,14 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["fdir", [\
       ["npm:6.5.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/fdir-npm-6.5.0-8814a0dec7-10c0.zip/node_modules/fdir/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/fdir-npm-6.5.0-8814a0dec7-10c0.zip/node_modules/fdir/",\
         "packageDependencies": [\
           ["fdir", "npm:6.5.0"]\
         ],\
         "linkType": "SOFT"\
       }],\
       ["virtual:0e783aadbd2b4b8e6f6056033c0b290501892d23bc7c5dad5477e00e48ad8bd3e4434c3962a52dd75a58e06dbb7218094a494bac954ef2f7f6fdb65d9717e5f4#npm:6.5.0", {\
-        "packageLocation": "./.yarn/__virtual__/fdir-virtual-abd4ab2082/4/.yarn/berry/cache/fdir-npm-6.5.0-8814a0dec7-10c0.zip/node_modules/fdir/",\
+        "packageLocation": "./.yarn/__virtual__/fdir-virtual-abd4ab2082/4/Users/chenyong/.yarn/berry/cache/fdir-npm-6.5.0-8814a0dec7-10c0.zip/node_modules/fdir/",\
         "packageDependencies": [\
           ["@types/picomatch", null],\
           ["fdir", "virtual:0e783aadbd2b4b8e6f6056033c0b290501892d23bc7c5dad5477e00e48ad8bd3e4434c3962a52dd75a58e06dbb7218094a494bac954ef2f7f6fdb65d9717e5f4#npm:6.5.0"],\
@@ -556,7 +556,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["fs-minipass", [\
       ["npm:3.0.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/fs-minipass-npm-3.0.3-d148d6ac19-10c0.zip/node_modules/fs-minipass/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/fs-minipass-npm-3.0.3-d148d6ac19-10c0.zip/node_modules/fs-minipass/",\
         "packageDependencies": [\
           ["fs-minipass", "npm:3.0.3"],\
           ["minipass", "npm:7.1.2"]\
@@ -576,7 +576,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["glob", [\
       ["npm:13.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/glob-npm-13.0.0-8e50143ca8-10c0.zip/node_modules/glob/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/glob-npm-13.0.0-8e50143ca8-10c0.zip/node_modules/glob/",\
         "packageDependencies": [\
           ["glob", "npm:13.0.0"],\
           ["minimatch", "npm:10.1.1"],\
@@ -588,7 +588,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["global", [\
       ["npm:4.4.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/global-npm-4.4.0-888ee8033d-10c0.zip/node_modules/global/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/global-npm-4.4.0-888ee8033d-10c0.zip/node_modules/global/",\
         "packageDependencies": [\
           ["global", "npm:4.4.0"],\
           ["min-document", "npm:2.19.2"],\
@@ -599,7 +599,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["graceful-fs", [\
       ["npm:4.2.11", {\
-        "packageLocation": "../../../.yarn/berry/cache/graceful-fs-npm-4.2.11-24bb648a68-10c0.zip/node_modules/graceful-fs/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/graceful-fs-npm-4.2.11-24bb648a68-10c0.zip/node_modules/graceful-fs/",\
         "packageDependencies": [\
           ["graceful-fs", "npm:4.2.11"]\
         ],\
@@ -608,7 +608,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["http-cache-semantics", [\
       ["npm:4.2.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/http-cache-semantics-npm-4.2.0-fadacfb3ad-10c0.zip/node_modules/http-cache-semantics/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/http-cache-semantics-npm-4.2.0-fadacfb3ad-10c0.zip/node_modules/http-cache-semantics/",\
         "packageDependencies": [\
           ["http-cache-semantics", "npm:4.2.0"]\
         ],\
@@ -617,7 +617,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["http-proxy-agent", [\
       ["npm:7.0.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/http-proxy-agent-npm-7.0.2-643ed7cc33-10c0.zip/node_modules/http-proxy-agent/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/http-proxy-agent-npm-7.0.2-643ed7cc33-10c0.zip/node_modules/http-proxy-agent/",\
         "packageDependencies": [\
           ["agent-base", "npm:7.1.4"],\
           ["debug", "virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3"],\
@@ -628,7 +628,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["https-proxy-agent", [\
       ["npm:7.0.6", {\
-        "packageLocation": "../../../.yarn/berry/cache/https-proxy-agent-npm-7.0.6-27a95c2690-10c0.zip/node_modules/https-proxy-agent/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/https-proxy-agent-npm-7.0.6-27a95c2690-10c0.zip/node_modules/https-proxy-agent/",\
         "packageDependencies": [\
           ["agent-base", "npm:7.1.4"],\
           ["debug", "virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3"],\
@@ -639,7 +639,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["iconv-lite", [\
       ["npm:0.6.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/iconv-lite-npm-0.6.3-24b8aae27e-10c0.zip/node_modules/iconv-lite/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/iconv-lite-npm-0.6.3-24b8aae27e-10c0.zip/node_modules/iconv-lite/",\
         "packageDependencies": [\
           ["iconv-lite", "npm:0.6.3"],\
           ["safer-buffer", "npm:2.1.2"]\
@@ -649,7 +649,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["imurmurhash", [\
       ["npm:0.1.4", {\
-        "packageLocation": "../../../.yarn/berry/cache/imurmurhash-npm-0.1.4-610c5068a0-10c0.zip/node_modules/imurmurhash/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/imurmurhash-npm-0.1.4-610c5068a0-10c0.zip/node_modules/imurmurhash/",\
         "packageDependencies": [\
           ["imurmurhash", "npm:0.1.4"]\
         ],\
@@ -658,7 +658,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["individual", [\
       ["npm:3.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/individual-npm-3.0.0-783c0f5e37-10c0.zip/node_modules/individual/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/individual-npm-3.0.0-783c0f5e37-10c0.zip/node_modules/individual/",\
         "packageDependencies": [\
           ["individual", "npm:3.0.0"]\
         ],\
@@ -667,7 +667,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["ip-address", [\
       ["npm:10.1.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/ip-address-npm-10.1.0-d5d5693401-10c0.zip/node_modules/ip-address/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/ip-address-npm-10.1.0-d5d5693401-10c0.zip/node_modules/ip-address/",\
         "packageDependencies": [\
           ["ip-address", "npm:10.1.0"]\
         ],\
@@ -676,7 +676,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["is-object", [\
       ["npm:1.0.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/is-object-npm-1.0.2-f72f6facf4-10c0.zip/node_modules/is-object/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/is-object-npm-1.0.2-f72f6facf4-10c0.zip/node_modules/is-object/",\
         "packageDependencies": [\
           ["is-object", "npm:1.0.2"]\
         ],\
@@ -685,7 +685,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["isexe", [\
       ["npm:3.1.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/isexe-npm-3.1.1-9c0061eead-10c0.zip/node_modules/isexe/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/isexe-npm-3.1.1-9c0061eead-10c0.zip/node_modules/isexe/",\
         "packageDependencies": [\
           ["isexe", "npm:3.1.1"]\
         ],\
@@ -694,7 +694,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["lightningcss", [\
       ["npm:1.31.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/lightningcss-npm-1.31.1-c7ba6b60a1-10c0.zip/node_modules/lightningcss/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/lightningcss-npm-1.31.1-c7ba6b60a1-10c0.zip/node_modules/lightningcss/",\
         "packageDependencies": [\
           ["detect-libc", "npm:2.1.2"],\
           ["lightningcss", "npm:1.31.1"],\
@@ -814,7 +814,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["lru-cache", [\
       ["npm:11.2.5", {\
-        "packageLocation": "../../../.yarn/berry/cache/lru-cache-npm-11.2.5-a56eb40aef-10c0.zip/node_modules/lru-cache/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/lru-cache-npm-11.2.5-a56eb40aef-10c0.zip/node_modules/lru-cache/",\
         "packageDependencies": [\
           ["lru-cache", "npm:11.2.5"]\
         ],\
@@ -823,7 +823,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["make-fetch-happen", [\
       ["npm:15.0.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/make-fetch-happen-npm-15.0.3-10a832fcad-10c0.zip/node_modules/make-fetch-happen/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/make-fetch-happen-npm-15.0.3-10a832fcad-10c0.zip/node_modules/make-fetch-happen/",\
         "packageDependencies": [\
           ["@npmcli/agent", "npm:4.0.0"],\
           ["cacache", "npm:20.0.3"],\
@@ -843,7 +843,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["min-document", [\
       ["npm:2.19.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/min-document-npm-2.19.2-3ed02fe99d-10c0.zip/node_modules/min-document/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/min-document-npm-2.19.2-3ed02fe99d-10c0.zip/node_modules/min-document/",\
         "packageDependencies": [\
           ["dom-walk", "npm:0.1.2"],\
           ["min-document", "npm:2.19.2"]\
@@ -853,7 +853,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minimatch", [\
       ["npm:10.1.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/minimatch-npm-10.1.1-453db4ee1a-10c0.zip/node_modules/minimatch/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minimatch-npm-10.1.1-453db4ee1a-10c0.zip/node_modules/minimatch/",\
         "packageDependencies": [\
           ["@isaacs/brace-expansion", "npm:5.0.0"],\
           ["minimatch", "npm:10.1.1"]\
@@ -863,7 +863,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minipass", [\
       ["npm:3.3.6", {\
-        "packageLocation": "../../../.yarn/berry/cache/minipass-npm-3.3.6-b8d93a945b-10c0.zip/node_modules/minipass/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minipass-npm-3.3.6-b8d93a945b-10c0.zip/node_modules/minipass/",\
         "packageDependencies": [\
           ["minipass", "npm:3.3.6"],\
           ["yallist", "npm:4.0.0"]\
@@ -871,7 +871,7 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }],\
       ["npm:7.1.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/minipass-npm-7.1.2-3a5327d36d-10c0.zip/node_modules/minipass/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minipass-npm-7.1.2-3a5327d36d-10c0.zip/node_modules/minipass/",\
         "packageDependencies": [\
           ["minipass", "npm:7.1.2"]\
         ],\
@@ -880,7 +880,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minipass-collect", [\
       ["npm:2.0.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/minipass-collect-npm-2.0.1-73d3907e40-10c0.zip/node_modules/minipass-collect/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minipass-collect-npm-2.0.1-73d3907e40-10c0.zip/node_modules/minipass-collect/",\
         "packageDependencies": [\
           ["minipass", "npm:7.1.2"],\
           ["minipass-collect", "npm:2.0.1"]\
@@ -890,7 +890,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minipass-fetch", [\
       ["npm:5.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/minipass-fetch-npm-5.0.0-e53c2bae4c-10c0.zip/node_modules/minipass-fetch/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minipass-fetch-npm-5.0.0-e53c2bae4c-10c0.zip/node_modules/minipass-fetch/",\
         "packageDependencies": [\
           ["encoding", "npm:0.1.13"],\
           ["minipass", "npm:7.1.2"],\
@@ -903,7 +903,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minipass-flush", [\
       ["npm:1.0.5", {\
-        "packageLocation": "../../../.yarn/berry/cache/minipass-flush-npm-1.0.5-efe79d9826-10c0.zip/node_modules/minipass-flush/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minipass-flush-npm-1.0.5-efe79d9826-10c0.zip/node_modules/minipass-flush/",\
         "packageDependencies": [\
           ["minipass", "npm:3.3.6"],\
           ["minipass-flush", "npm:1.0.5"]\
@@ -913,7 +913,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minipass-pipeline", [\
       ["npm:1.2.4", {\
-        "packageLocation": "../../../.yarn/berry/cache/minipass-pipeline-npm-1.2.4-5924cb077f-10c0.zip/node_modules/minipass-pipeline/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minipass-pipeline-npm-1.2.4-5924cb077f-10c0.zip/node_modules/minipass-pipeline/",\
         "packageDependencies": [\
           ["minipass", "npm:3.3.6"],\
           ["minipass-pipeline", "npm:1.2.4"]\
@@ -923,7 +923,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minipass-sized", [\
       ["npm:1.0.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/minipass-sized-npm-1.0.3-306d86f432-10c0.zip/node_modules/minipass-sized/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minipass-sized-npm-1.0.3-306d86f432-10c0.zip/node_modules/minipass-sized/",\
         "packageDependencies": [\
           ["minipass", "npm:3.3.6"],\
           ["minipass-sized", "npm:1.0.3"]\
@@ -933,7 +933,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["minizlib", [\
       ["npm:3.1.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/minizlib-npm-3.1.0-6680befdba-10c0.zip/node_modules/minizlib/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/minizlib-npm-3.1.0-6680befdba-10c0.zip/node_modules/minizlib/",\
         "packageDependencies": [\
           ["minipass", "npm:7.1.2"],\
           ["minizlib", "npm:3.1.0"]\
@@ -943,7 +943,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["ms", [\
       ["npm:2.1.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/ms-npm-2.1.3-81ff3cfac1-10c0.zip/node_modules/ms/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/ms-npm-2.1.3-81ff3cfac1-10c0.zip/node_modules/ms/",\
         "packageDependencies": [\
           ["ms", "npm:2.1.3"]\
         ],\
@@ -952,14 +952,14 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["nanoid", [\
       ["npm:3.3.11", {\
-        "packageLocation": "../../../.yarn/berry/cache/nanoid-npm-3.3.11-f98c1f9ef6-10c0.zip/node_modules/nanoid/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/nanoid-npm-3.3.11-f98c1f9ef6-10c0.zip/node_modules/nanoid/",\
         "packageDependencies": [\
           ["nanoid", "npm:3.3.11"]\
         ],\
         "linkType": "HARD"\
       }],\
       ["npm:4.0.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/nanoid-npm-4.0.2-ae010cad86-10c0.zip/node_modules/nanoid/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/nanoid-npm-4.0.2-ae010cad86-10c0.zip/node_modules/nanoid/",\
         "packageDependencies": [\
           ["nanoid", "npm:4.0.2"]\
         ],\
@@ -968,7 +968,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["negotiator", [\
       ["npm:1.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/negotiator-npm-1.0.0-47d727e27e-10c0.zip/node_modules/negotiator/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/negotiator-npm-1.0.0-47d727e27e-10c0.zip/node_modules/negotiator/",\
         "packageDependencies": [\
           ["negotiator", "npm:1.0.0"]\
         ],\
@@ -977,7 +977,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["next-tick", [\
       ["npm:0.2.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/next-tick-npm-0.2.2-2d1ea03b94-10c0.zip/node_modules/next-tick/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/next-tick-npm-0.2.2-2d1ea03b94-10c0.zip/node_modules/next-tick/",\
         "packageDependencies": [\
           ["next-tick", "npm:0.2.2"]\
         ],\
@@ -1005,7 +1005,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["nopt", [\
       ["npm:9.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/nopt-npm-9.0.0-81316ec15c-10c0.zip/node_modules/nopt/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/nopt-npm-9.0.0-81316ec15c-10c0.zip/node_modules/nopt/",\
         "packageDependencies": [\
           ["abbrev", "npm:4.0.0"],\
           ["nopt", "npm:9.0.0"]\
@@ -1015,7 +1015,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["p-map", [\
       ["npm:7.0.4", {\
-        "packageLocation": "../../../.yarn/berry/cache/p-map-npm-7.0.4-39386109d0-10c0.zip/node_modules/p-map/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/p-map-npm-7.0.4-39386109d0-10c0.zip/node_modules/p-map/",\
         "packageDependencies": [\
           ["p-map", "npm:7.0.4"]\
         ],\
@@ -1024,7 +1024,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["path-scurry", [\
       ["npm:2.0.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/path-scurry-npm-2.0.1-7744619e5d-10c0.zip/node_modules/path-scurry/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/path-scurry-npm-2.0.1-7744619e5d-10c0.zip/node_modules/path-scurry/",\
         "packageDependencies": [\
           ["lru-cache", "npm:11.2.5"],\
           ["minipass", "npm:7.1.2"],\
@@ -1035,7 +1035,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["picocolors", [\
       ["npm:1.1.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/picocolors-npm-1.1.1-4fede47cf1-10c0.zip/node_modules/picocolors/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/picocolors-npm-1.1.1-4fede47cf1-10c0.zip/node_modules/picocolors/",\
         "packageDependencies": [\
           ["picocolors", "npm:1.1.1"]\
         ],\
@@ -1044,7 +1044,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["picomatch", [\
       ["npm:4.0.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/picomatch-npm-4.0.3-0a647b87cc-10c0.zip/node_modules/picomatch/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/picomatch-npm-4.0.3-0a647b87cc-10c0.zip/node_modules/picomatch/",\
         "packageDependencies": [\
           ["picomatch", "npm:4.0.3"]\
         ],\
@@ -1053,7 +1053,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["postcss", [\
       ["npm:8.5.6", {\
-        "packageLocation": "../../../.yarn/berry/cache/postcss-npm-8.5.6-e7f126c6f3-10c0.zip/node_modules/postcss/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/postcss-npm-8.5.6-e7f126c6f3-10c0.zip/node_modules/postcss/",\
         "packageDependencies": [\
           ["nanoid", "npm:3.3.11"],\
           ["picocolors", "npm:1.1.1"],\
@@ -1065,7 +1065,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["proc-log", [\
       ["npm:6.1.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/proc-log-npm-6.1.0-84e609b3f4-10c0.zip/node_modules/proc-log/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/proc-log-npm-6.1.0-84e609b3f4-10c0.zip/node_modules/proc-log/",\
         "packageDependencies": [\
           ["proc-log", "npm:6.1.0"]\
         ],\
@@ -1074,7 +1074,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["process", [\
       ["npm:0.11.10", {\
-        "packageLocation": "../../../.yarn/berry/cache/process-npm-0.11.10-aeb3b641ae-10c0.zip/node_modules/process/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/process-npm-0.11.10-aeb3b641ae-10c0.zip/node_modules/process/",\
         "packageDependencies": [\
           ["process", "npm:0.11.10"]\
         ],\
@@ -1083,7 +1083,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["promise-retry", [\
       ["npm:2.0.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/promise-retry-npm-2.0.1-871f0b01b7-10c0.zip/node_modules/promise-retry/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/promise-retry-npm-2.0.1-871f0b01b7-10c0.zip/node_modules/promise-retry/",\
         "packageDependencies": [\
           ["err-code", "npm:2.0.3"],\
           ["promise-retry", "npm:2.0.1"],\
@@ -1094,7 +1094,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["retry", [\
       ["npm:0.12.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/retry-npm-0.12.0-72ac7fb4cc-10c0.zip/node_modules/retry/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/retry-npm-0.12.0-72ac7fb4cc-10c0.zip/node_modules/retry/",\
         "packageDependencies": [\
           ["retry", "npm:0.12.0"]\
         ],\
@@ -1103,7 +1103,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["rolldown", [\
       ["npm:1.0.0-rc.6", {\
-        "packageLocation": "../../../.yarn/berry/cache/rolldown-npm-1.0.0-rc.6-cfa06a43be-10c0.zip/node_modules/rolldown/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/rolldown-npm-1.0.0-rc.6-cfa06a43be-10c0.zip/node_modules/rolldown/",\
         "packageDependencies": [\
           ["@oxc-project/types", "npm:0.115.0"],\
           ["@rolldown/binding-android-arm64", "npm:1.0.0-rc.6"],\
@@ -1129,7 +1129,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:.", {\
         "packageLocation": "./",\
         "packageDependencies": [\
-          ["@calcit/procs", "npm:0.12.11"],\
+          ["@calcit/procs", "npm:0.13.33"],\
           ["bottom-tip", "npm:0.1.5"],\
           ["cirru-color", "npm:0.2.4"],\
           ["copy-text-to-clipboard", "npm:3.2.2"],\
@@ -1142,7 +1142,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["safer-buffer", [\
       ["npm:2.1.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/safer-buffer-npm-2.1.2-8d5c0b705e-10c0.zip/node_modules/safer-buffer/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/safer-buffer-npm-2.1.2-8d5c0b705e-10c0.zip/node_modules/safer-buffer/",\
         "packageDependencies": [\
           ["safer-buffer", "npm:2.1.2"]\
         ],\
@@ -1151,7 +1151,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["semver", [\
       ["npm:7.7.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/semver-npm-7.7.3-9cf7b3b46c-10c0.zip/node_modules/semver/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/semver-npm-7.7.3-9cf7b3b46c-10c0.zip/node_modules/semver/",\
         "packageDependencies": [\
           ["semver", "npm:7.7.3"]\
         ],\
@@ -1160,7 +1160,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["smart-buffer", [\
       ["npm:4.2.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/smart-buffer-npm-4.2.0-5ac3f668bb-10c0.zip/node_modules/smart-buffer/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/smart-buffer-npm-4.2.0-5ac3f668bb-10c0.zip/node_modules/smart-buffer/",\
         "packageDependencies": [\
           ["smart-buffer", "npm:4.2.0"]\
         ],\
@@ -1169,7 +1169,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["socks", [\
       ["npm:2.8.7", {\
-        "packageLocation": "../../../.yarn/berry/cache/socks-npm-2.8.7-d1d20aae19-10c0.zip/node_modules/socks/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/socks-npm-2.8.7-d1d20aae19-10c0.zip/node_modules/socks/",\
         "packageDependencies": [\
           ["ip-address", "npm:10.1.0"],\
           ["smart-buffer", "npm:4.2.0"],\
@@ -1180,7 +1180,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["socks-proxy-agent", [\
       ["npm:8.0.5", {\
-        "packageLocation": "../../../.yarn/berry/cache/socks-proxy-agent-npm-8.0.5-24d77a90dc-10c0.zip/node_modules/socks-proxy-agent/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/socks-proxy-agent-npm-8.0.5-24d77a90dc-10c0.zip/node_modules/socks-proxy-agent/",\
         "packageDependencies": [\
           ["agent-base", "npm:7.1.4"],\
           ["debug", "virtual:643ed7cc338bcf145a82d8b05b3bef6bcf150ca545df386225596f10ce53cc90b88b3ca83e348ade1ccea5f3f8e76c92d2f0e2ba544da60d40aff9921c56872d#npm:4.4.3"],\
@@ -1192,7 +1192,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["source-map-js", [\
       ["npm:1.2.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/source-map-js-npm-1.2.1-b9a47d7e1a-10c0.zip/node_modules/source-map-js/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/source-map-js-npm-1.2.1-b9a47d7e1a-10c0.zip/node_modules/source-map-js/",\
         "packageDependencies": [\
           ["source-map-js", "npm:1.2.1"]\
         ],\
@@ -1201,7 +1201,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["ssri", [\
       ["npm:13.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/ssri-npm-13.0.0-f5fa93375d-10c0.zip/node_modules/ssri/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/ssri-npm-13.0.0-f5fa93375d-10c0.zip/node_modules/ssri/",\
         "packageDependencies": [\
           ["minipass", "npm:7.1.2"],\
           ["ssri", "npm:13.0.0"]\
@@ -1211,7 +1211,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["string-template", [\
       ["npm:0.2.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/string-template-npm-0.2.1-e8fa722df5-10c0.zip/node_modules/string-template/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/string-template-npm-0.2.1-e8fa722df5-10c0.zip/node_modules/string-template/",\
         "packageDependencies": [\
           ["string-template", "npm:0.2.1"]\
         ],\
@@ -1220,7 +1220,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["tar", [\
       ["npm:7.5.7", {\
-        "packageLocation": "../../../.yarn/berry/cache/tar-npm-7.5.7-053aec5a88-10c0.zip/node_modules/tar/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/tar-npm-7.5.7-053aec5a88-10c0.zip/node_modules/tar/",\
         "packageDependencies": [\
           ["@isaacs/fs-minipass", "npm:4.0.1"],\
           ["chownr", "npm:3.0.0"],\
@@ -1234,7 +1234,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["tinyglobby", [\
       ["npm:0.2.15", {\
-        "packageLocation": "../../../.yarn/berry/cache/tinyglobby-npm-0.2.15-0e783aadbd-10c0.zip/node_modules/tinyglobby/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/tinyglobby-npm-0.2.15-0e783aadbd-10c0.zip/node_modules/tinyglobby/",\
         "packageDependencies": [\
           ["fdir", "virtual:0e783aadbd2b4b8e6f6056033c0b290501892d23bc7c5dad5477e00e48ad8bd3e4434c3962a52dd75a58e06dbb7218094a494bac954ef2f7f6fdb65d9717e5f4#npm:6.5.0"],\
           ["picomatch", "npm:4.0.3"],\
@@ -1245,7 +1245,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["tslib", [\
       ["npm:2.8.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/tslib-npm-2.8.1-66590b21b8-10c0.zip/node_modules/tslib/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/tslib-npm-2.8.1-66590b21b8-10c0.zip/node_modules/tslib/",\
         "packageDependencies": [\
           ["tslib", "npm:2.8.1"]\
         ],\
@@ -1254,7 +1254,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["unique-filename", [\
       ["npm:5.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/unique-filename-npm-5.0.0-605f54f18e-10c0.zip/node_modules/unique-filename/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/unique-filename-npm-5.0.0-605f54f18e-10c0.zip/node_modules/unique-filename/",\
         "packageDependencies": [\
           ["unique-filename", "npm:5.0.0"],\
           ["unique-slug", "npm:6.0.0"]\
@@ -1264,7 +1264,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["unique-slug", [\
       ["npm:6.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/unique-slug-npm-6.0.0-f26b186e99-10c0.zip/node_modules/unique-slug/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/unique-slug-npm-6.0.0-f26b186e99-10c0.zip/node_modules/unique-slug/",\
         "packageDependencies": [\
           ["imurmurhash", "npm:0.1.4"],\
           ["unique-slug", "npm:6.0.0"]\
@@ -1274,7 +1274,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["virtual-dom", [\
       ["npm:2.1.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/virtual-dom-npm-2.1.1-8a39158cf1-10c0.zip/node_modules/virtual-dom/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/virtual-dom-npm-2.1.1-8a39158cf1-10c0.zip/node_modules/virtual-dom/",\
         "packageDependencies": [\
           ["browser-split", "npm:0.0.1"],\
           ["error", "npm:4.4.0"],\
@@ -1291,14 +1291,14 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["vite", [\
       ["npm:8.0.0-beta.16", {\
-        "packageLocation": "../../../.yarn/berry/cache/vite-npm-8.0.0-beta.16-d82505fa41-10c0.zip/node_modules/vite/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/vite-npm-8.0.0-beta.16-d82505fa41-10c0.zip/node_modules/vite/",\
         "packageDependencies": [\
           ["vite", "npm:8.0.0-beta.16"]\
         ],\
         "linkType": "SOFT"\
       }],\
       ["virtual:dc3fc578bfa5e06182a4d2be39ede0bc5b74940b1ffe0d70c26892ab140a4699787750fba175dc306292e80b4aa2c8c5f68c2a821e69b2c37e360c0dff36ff66#npm:8.0.0-beta.16", {\
-        "packageLocation": "./.yarn/__virtual__/vite-virtual-e9d6f177e4/4/.yarn/berry/cache/vite-npm-8.0.0-beta.16-d82505fa41-10c0.zip/node_modules/vite/",\
+        "packageLocation": "./.yarn/__virtual__/vite-virtual-e9d6f177e4/4/Users/chenyong/.yarn/berry/cache/vite-npm-8.0.0-beta.16-d82505fa41-10c0.zip/node_modules/vite/",\
         "packageDependencies": [\
           ["@oxc-project/runtime", "npm:0.115.0"],\
           ["@types/esbuild", null],\
@@ -1362,7 +1362,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["which", [\
       ["npm:6.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/which-npm-6.0.0-48f25f0ec8-10c0.zip/node_modules/which/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/which-npm-6.0.0-48f25f0ec8-10c0.zip/node_modules/which/",\
         "packageDependencies": [\
           ["isexe", "npm:3.1.1"],\
           ["which", "npm:6.0.0"]\
@@ -1372,7 +1372,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["x-is-array", [\
       ["npm:0.1.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/x-is-array-npm-0.1.0-c49b0e68b6-10c0.zip/node_modules/x-is-array/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/x-is-array-npm-0.1.0-c49b0e68b6-10c0.zip/node_modules/x-is-array/",\
         "packageDependencies": [\
           ["x-is-array", "npm:0.1.0"]\
         ],\
@@ -1381,7 +1381,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["x-is-string", [\
       ["npm:0.1.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/x-is-string-npm-0.1.0-a254bc0c3e-10c0.zip/node_modules/x-is-string/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/x-is-string-npm-0.1.0-a254bc0c3e-10c0.zip/node_modules/x-is-string/",\
         "packageDependencies": [\
           ["x-is-string", "npm:0.1.0"]\
         ],\
@@ -1390,7 +1390,7 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["xtend", [\
       ["npm:4.0.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/xtend-npm-4.0.2-7f2375736e-10c0.zip/node_modules/xtend/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/xtend-npm-4.0.2-7f2375736e-10c0.zip/node_modules/xtend/",\
         "packageDependencies": [\
           ["xtend", "npm:4.0.2"]\
         ],\
@@ -1399,14 +1399,14 @@ const RAW_RUNTIME_STATE =
     ]],\
     ["yallist", [\
       ["npm:4.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/yallist-npm-4.0.0-b493d9e907-10c0.zip/node_modules/yallist/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/yallist-npm-4.0.0-b493d9e907-10c0.zip/node_modules/yallist/",\
         "packageDependencies": [\
           ["yallist", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }],\
       ["npm:5.0.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/yallist-npm-5.0.0-8732dd9f1c-10c0.zip/node_modules/yallist/",\
+        "packageLocation": "../../../Users/chenyong/.yarn/berry/cache/yallist-npm-5.0.0-8732dd9f1c-10c0.zip/node_modules/yallist/",\
         "packageDependencies": [\
           ["yallist", "npm:5.0.0"]\
         ],\

--- a/Agents.md
+++ b/Agents.md
@@ -1,38 +1,30 @@
-Developer runs `cr js` to watch build JavaScript, and `yarn vite` to start a local server. LLMs edits program by running `cr` commands, and then triggers re-compiling.
+# Calcit Agent 指南
 
-查看 Calcit 命令行工具的用法:
+本项目使用 canonical `calcit.cirru` 作为源码快照，不再维护 `compact.cirru`。
 
-```bash
-cr docs agents --full
-```
-
-查看 Respo 模块的具体用法
+开始查询或修改前，先读取当前 CLI 指南：
 
 ```bash
-cr libs readme respo.calcit -f docs/Respo-Agent.md
+calcit docs agents --full
 ```
 
-## LLM 执行效率优化（不重复 llms/Calcit.md）
+需要了解升级、快照格式、依赖或结构化编辑时，直接查询内置文档：
 
-- **先定位再修改**：先读结构/需求，再做最小变更，避免“改一处→报错→补救”式迭代。
-- **缓存上下文**：记录你已经确认的定义位置与修改点，避免重复搜索相同目标。
-- **优先局部替换**：只替换目标节点或小段结构，避免整段重写导致结构漂移。
-- **拆分复杂改动**：把 UI 改动与逻辑改动拆开，减少单次变更影响面。
-- **尽量复用已有组件/样式**：优先扩展已有样式/组件，而不是新增并重复实现。
-- **检查生成代码风险点**：处理 `let`、map 结构、属性 map 的键值对等高风险结构时，先确认结构是否符合预期，再替换。
-- **利用 diff 控制范围**：在多次修改后随时对比 diff，避免无关变更积累。
-- **编译前自检**：对于复杂变更，先手动检查节点结构（比如嵌套列表、属性 map、函数参数形态）再编译。
-- **输出稳定性优先**：避免频繁调整格式或样式细节，优先保证逻辑稳定与可读性。
+```bash
+calcit docs read upgrade --full
+calcit docs read project-structure.md --full
+calcit tree --help
+calcit edit --help
+```
 
-## 常见错误与正确做法（结合本项目实践）
+常用验证命令：
 
-- **`let` 只保留最后一个表达式**：多个表达式需要包一层 `div`/`do`，否则前面的节点会被丢掉。
-- **属性 map 必须是成对键值**：避免把 `:style` 与 `:inner-text` 写在同一个 pair 内；每个属性单独成对。
-- **避免生成“可调用字符串”**：形如 `(<> ((str ...)))` 会变成调用结果，正确写法为 `<> $ str ...`。
-- **列表 vs set**：`keys` 返回 set，拼接前先 `.to-list`，再 `concat`。
-- **pairs 列表转 map**：不要用 `.to-map` 处理 list，改用 `pairs-map`。
-- **函数调用与变量区分**：`week-start` 这类变量必须 is-leaf，避免成为单元素 list 导致被当做“函数调用”。
-- **数值与单位风险**：CSS 属性如 `flex`, `font-weight`, `line-height`, `z-index` 若使用单纯数字，Respo 会自动拼接 `px` 单位。必须改为字符串形式，例如 `:flex "\"1"` 或 `:font-weight "\"300"`。
-- **结构化编辑优先**：严禁直接编辑 `compact.cirru`，必须使用 `cr tree replace` 或 `cr edit def` 等命令。建议先通过 `cr query search 'keyword' -f 'ns/def'` 精确获得 node 路径。
-- **性能优化准则**：对于动态生成的列表（如任务项），应将静态样式从内联 `:style` 提取到 `defstyle` 中，通过 `:class-name` 引用以提升虚拟 DOM 性能。
-- **排序逻辑翻转**：翻转列表排序应直接修改 `sort` 函数所用比较器的返回分支（如将 `if ret 1 -1` 翻转为 `if ret -1 1`）。
+```bash
+caps --ci
+calcit calcit.cirru edit format
+calcit calcit.cirru --check-only
+calcit calcit.cirru js
+yarn vite
+```
+
+不要用文本替换直接修改 `calcit.cirru`；使用 `calcit edit`、`calcit tree` 或其他文档中说明的结构化命令。Respo API 和项目特定约定也通过 `calcit docs read <doc>` 查询，不在本文件重复维护。

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,7 +1,8 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.0.1)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |app)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :js) (:reload-fn 'app.main/reload!)
+      :feature-policy $ {}
       :modules $ [] |respo.calcit/ |lilac/ |memof/ |respo-ui.calcit/ |respo-markdown.calcit/ |reel.calcit/
       :type-slots $ {}
   :files $ {}
@@ -1056,7 +1057,7 @@
               :bookmarks $ :: 'List 'Tag 'Dynamic
               :pointer 'Number
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'StructDef
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.types)
     |app.updater $ %{} 'FileEntry

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1057,7 +1057,7 @@
               :bookmarks $ :: 'List 'Tag 'Dynamic
               :pointer 'Number
           :examples $ []
-          :schema $ :: 'StructDef
+          :schema $ :: 'Enum
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.types)
     |app.updater $ %{} 'FileEntry

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,8 +1,9 @@
 
-{} (:calcit-version |0.13.15)
-  :dependencies $ {} (|Respo/reel.calcit |main)
-    |Respo/respo-markdown.calcit |0.4.22
-    |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.69
-    |calcit-lang/lilac |0.5.1
-    |calcit-lang/memof |0.0.26
+{} (:calcit-version |0.13.33)
+  :version |0.0.2
+  :dependencies $ {} (|Respo/reel.calcit |0.6.7)
+    |Respo/respo-markdown.calcit |0.4.23
+    |Respo/respo-ui.calcit |0.7.10
+    |Respo/respo.calcit |0.16.83
+    |calcit-lang/lilac |0.5.5
+    |calcit-lang/memof |0.0.28

--- a/history/2026082303-migrate-calcit-01333.md
+++ b/history/2026082303-migrate-calcit-01333.md
@@ -1,0 +1,6 @@
+# 2026-08-23 Calcit 0.13.33 migration
+
+- Updated dependencies and `@calcit/procs` to Calcit 0.13.33.
+- Replaced the remaining workflow `cr` path with `calcit`.
+- Pinned setup-calcit to `v1.3.0` and requested `calcit,caps` explicitly.
+- Replaced the main branch Respo Reel dependency with release 0.6.7.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.15",
+    "@calcit/procs": "^0.13.33",
     "cirru-color": "0.2.4",
     "copy-text-to-clipboard": "3.2.2",
     "dayjs": "1.11.20"
@@ -9,6 +9,6 @@
     "bottom-tip": "^0.1.5",
     "vite": "^8.0.0-beta.16"
   },
-  "version": "0.0.1",
+  "version": "0.0.2",
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.15":
-  version: 0.13.15
-  resolution: "@calcit/procs@npm:0.13.15"
+"@calcit/procs@npm:^0.13.33":
+  version: 0.13.33
+  resolution: "@calcit/procs@npm:0.13.33"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
+  checksum: 10c0/132fa43ee4b5edb12bbdb04b11f528e73842752d2b7ec8dd716357129aa6e35f80fac35da87b8d09a17f0ad5f78572d8359bf7a9b7aa0c2cbc4e313569cdab6e
   languageName: node
   linkType: hard
 
@@ -985,7 +985,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.15"
+    "@calcit/procs": "npm:^0.13.33"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:0.2.4"
     copy-text-to-clipboard: "npm:3.2.2"


### PR DESCRIPTION
Upgrade the canonical snapshot, released module dependencies, package procs, and CI to Calcit 0.13.33. Simplify the agent guide to refer to calcit docs.\n\nValidation: caps --ci; calcit calcit.cirru edit format; calcit calcit.cirru --check-only; yarn install --immutable.